### PR TITLE
Add Laminar to libraries

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -212,6 +212,19 @@
           }
         ],
         "compileTimeOnly": false
+      },
+      {
+        "name": "Laminar",
+        "organization": "com.raquo",
+        "artifact": "laminar",
+        "doc": "https://github.com/raquo/Laminar",
+        "versions": [
+          {
+            "version": "0.4",
+            "scalaVersions": ["2.11", "2.12"]
+          }
+        ],
+        "compileTimeOnly": false
       }
     ]
   },


### PR DESCRIPTION
Trying to add Laminar (https://github.com/raquo/Laminar) to the dependency list. Couldn't get scalafiddle running locally to try it out, but I think it should work.

I don't think the author, Raquo, will mind but I'll ping him on gitter just to be sure.