### PR TITLE
Resurrect cats-mtl-core 0.4.0

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -393,6 +393,19 @@
         ],
         "compileTimeOnly": false
       },
+      {	
+        "name": "Cats MTL",	
+        "organization": "org.typelevel",	
+        "artifact": "cats-mtl-core",	
+        "doc": "typelevel/cats-mtl",	
+        "versions": [	
+          {	
+            "version": "0.4.0",	
+            "scalaVersions": ["2.11", "2.12"]	
+          }	
+        ],	
+        "compileTimeOnly": false	
+      },
       {
         "name": "Scalaz",
         "organization": "org.scalaz",


### PR DESCRIPTION
I hope this is enough to revert the revert on #23 . Unless there is more to it I saw that the correct artifact should be cats-mtl-core instead of cats-mtl