### PR TITLE
Add Udash 0.8

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -150,11 +150,38 @@
       {
         "name": "Udash",
         "organization": "io.udash",
-        "artifact": "udash-core-frontend",
+        "artifact": "udash-core",
         "doc": "https://udash.io",
         "versions": [
           {
+            "version": "0.8.1",
+            "scalaVersions": ["2.11", "2.12"],
+            "extraDeps": [
+              "io.udash %%% udash-auth % 0.8.1",
+              "io.udash %%% udash-bootstrap4 % 0.8.1",
+              "io.udash %%% udash-charts % 0.8.1",
+              "io.udash %%% udash-css % 0.8.1",
+              "io.udash %%% udash-i18n % 0.8.1",
+              "io.udash %%% udash-rpc % 0.8.1",
+              "io.udash %%% udash-rest % 0.8.1"
+            ],
+            "jsDeps": [
+              "bootstrap % 4.1.3 % https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js",
+              "jquery % 3.3.1 % https://code.jquery.com/jquery-3.3.1.min.js",
+              "highcharts % 5.0.14 % https://code.highcharts.com/5.0.14/highcharts.js",
+              "highcharts-3d % 5.0.14 % https://code.highcharts.com/5.0.14/highcharts-3d.js",
+              "highcharts-more % 5.0.14 % https://code.highcharts.com/5.0.14/highcharts-more.js",
+              "highcharts-exporting % 5.0.14 % https://code.highcharts.com/5.0.14/modules/exporting.js",
+              "highcharts-drilldown % 5.0.14 % https://code.highcharts.com/5.0.14/modules/drilldown.js",
+              "highcharts-heatmap % 5.0.14 % https://code.highcharts.com/5.0.14/modules/heatmap.js"
+            ],
+            "cssDeps": [
+              "bootstrap % 4.1.3 % https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+            ]
+          },
+          {
             "version": "0.7.1",
+            "artifact": "udash-core-frontend",
             "scalaVersions": ["2.11", "2.12"],
             "extraDeps": [
               "io.udash %%% udash-auth-frontend % 0.7.1",
@@ -181,6 +208,7 @@
           },
           {
             "version": "0.6.0",
+            "artifact": "udash-core-frontend",
             "scalaVersions": ["2.11", "2.12"],
             "extraDeps": [
               "io.udash %%% udash-auth-frontend % 0.6.0",
@@ -193,6 +221,7 @@
           },
           {
             "version": "0.5.0",
+            "artifact": "udash-core-frontend",
             "scalaVersions": ["2.11", "2.12"],
             "extraDeps": [
               "io.udash %%% udash-bootstrap % 0.5.0",
@@ -204,6 +233,7 @@
           },
           {
             "version": "0.4.0",
+            "artifact": "udash-core-frontend",
             "scalaVersions": ["2.11"],
             "extraDeps": [
               "io.udash %%% udash-bootstrap % 0.4.0",
@@ -214,6 +244,7 @@
           },
           {
             "version": "0.3.1",
+            "artifact": "udash-core-frontend",
             "scalaVersions": ["2.11"],
             "extraDeps": [
               "io.udash %%% udash-bootstrap % 0.3.1",


### PR DESCRIPTION
The artifact naming scheme changed in 0.8.x, but it seems it's possible to override the name at the version level - kudos for foreseeing that in the implementation of ScalaFiddle :trophy: