### PR TITLE
Add Laminar version 0.9.0

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -291,6 +291,11 @@
         "doc": "https://github.com/raquo/Laminar",
         "versions": [
           {
+            "version": "0.8.0",
+            "scalaVersions": ["2.12", "2.13"],
+            "scalaJSVersions": ["1"]
+          },
+          {
             "version": "0.7.2",
             "scalaVersions": ["2.12"]
           },

--- a/libraries.json
+++ b/libraries.json
@@ -291,7 +291,7 @@
         "doc": "https://github.com/raquo/Laminar",
         "versions": [
           {
-            "version": "0.8.0",
+            "version": "0.9.0",
             "scalaVersions": ["2.12", "2.13"],
             "scalaJSVersions": ["1"]
           },


### PR DESCRIPTION
(Yes, it only works with Scala.js 1.x)

EDIT: ~~Argh sorry hold up, I forgot to press enter on `sonatypeRelease`. Give it a few minutes to show up in Maven.~~ Alright, fixed now.