### PR TITLE
Add html.scala

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -890,6 +890,19 @@
           }
         ],
         "compileTimeOnly": false
+      },
+      {
+        "name": "html.scala",
+        "organization": "org.lrng.binding",
+        "artifact": "html",
+        "doc": "GlasslabGames/html.scala",
+        "versions": [
+          {
+            "version": "1.0.3",
+            "scalaVersions": ["2.11", "2.12", "2.13"]
+          }
+        ],
+        "compileTimeOnly": false
       }
     ]
   },

--- a/libraries.json
+++ b/libraries.json
@@ -3,6 +3,19 @@
     "group": "Web",
     "libraries": [
       {
+        "name": "html.scala",
+        "organization": "org.lrng.binding",
+        "artifact": "html",
+        "doc": "GlasslabGames/html.scala",
+        "versions": [
+          {
+            "version": "1.0.3",
+            "scalaVersions": ["2.11", "2.12", "2.13"]
+          }
+        ],
+        "compileTimeOnly": false
+      },
+      {
         "name": "Slinky",
         "organization": "me.shadaj",
         "artifact": "slinky-core",
@@ -887,19 +900,6 @@
           {
             "version": "1.0.1",
             "scalaVersions": ["2.11", "2.12"]
-          }
-        ],
-        "compileTimeOnly": false
-      },
-      {
-        "name": "html.scala",
-        "organization": "org.lrng.binding",
-        "artifact": "html",
-        "doc": "GlasslabGames/html.scala",
-        "versions": [
-          {
-            "version": "1.0.3",
-            "scalaVersions": ["2.11", "2.12", "2.13"]
           }
         ],
         "compileTimeOnly": false


### PR DESCRIPTION
html.scala is It is a reimplementation of @dom annotation of Binding.scala for creating reactive HTML templates.